### PR TITLE
FIX: name 'bpy' is not defined

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -382,6 +382,7 @@ Configure the turtle to place a sphere when it encounters an X in the lsystem st
 ```
 import mathutils
 import bmesh
+import bpy
 import lsystem.exec
 import lsystem.util
 


### PR DESCRIPTION
The Custom Interpretations example needs 'import bpy' otherwise a "name 'bpy' is not defined" error is thrown in Blender 2.81a.